### PR TITLE
golangによるテストサーバを構築

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+From golang:1.14rc1-alpine3.11
+
+WORKDIR /go
+COPY . .
+
+CMD ["go", "run", "main.go"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+build-image:
+	docker build . -t treevel-server
+
+run:
+	docker run -p 8080:8080 -d treevel-server:latest

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Treevel-server
+
+This is a backend for [native app](https://github.com/LITO-apps/Treevel-client)
+
+## How to Run
+
+### Requirements
+
+- `Docker Engine: v19.03.5`
+
+### Build api server on docker
+
+```
+make build-image
+```
+
+### Run server
+
+```
+make run
+```

--- a/main.go
+++ b/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+)
+
+func handler(w http.ResponseWriter, r *http.Request)  {
+	dump, err := httputil.DumpRequest(r, true)
+
+	if err != nil {
+		http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+		return
+	}
+
+	fmt.Println(string(dump))
+
+	// FIXME: Unhandled error
+	fmt.Fprint(w, "hello world!\n")
+}
+
+func main()  {
+	var httpServer http.Server
+	// Port number
+	httpServer.Addr = ":8080"
+	// Rooting
+	http.HandleFunc("/", handler)
+	// Log
+	log.Println("Server Start" + httpServer.Addr)
+	// Listen
+	log.Println(httpServer.ListenAndServe())
+}


### PR DESCRIPTION
Close #1 

## 概要
- Docker上でサーバを構築するテストスクリプトを作成
- ポート番号は，`8080`
- `docker`コマンドを極力叩かずに済むように，`Makefile`を作成

## テスト方法
- `README`に記述

## 今後のタスク
簡易的な実装なため，課題は沢山存在する
- api サーバ向けのアーキテクチャ設計
- dbの導入
- dbの導入に際して，`docker-compose.yml`を記述