### PR TITLE
リクエストに対するルーティングに外部パッケージを用いる

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.go]
+charset=utf-8
+end_of_line=lf
+trim_trailing_whitespace=true
+insert_final_newline=true
+indent_style=space
+indent_size=4

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,6 @@ FROM golang:1.14-alpine3.11
 WORKDIR /go
 COPY . .
 
-CMD ["go", "run", "main.go"]
+RUN go build -mod=readonly -o app main.go
+
+CMD ["./app"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM golang:1.14-alpine3.11
 
-WORKDIR /go
+WORKDIR /go/src/app
+
 COPY . .
 
 RUN go build -mod=readonly -o app main.go
+
+EXPOSE 8080
 
 CMD ["./app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 
 services:
-  go:
+  app:
     build: .
     ports:
       - "8080:8080"

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/LITO-apps/Treevel-server
+
+go 1.13
+
+require github.com/julienschmidt/httprouter v1.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/LITO-apps/Treevel-server
 
 go 1.13
 
-require github.com/julienschmidt/httprouter v1.3.0 // indirect
+require github.com/julienschmidt/httprouter v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
+github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=

--- a/main.go
+++ b/main.go
@@ -1,38 +1,42 @@
 package main
 
 import (
-	"fmt"
-	"log"
-	"net/http"
-	"net/http/httputil"
+    "fmt"
+    "log"
+    "net/http"
+    "net/http/httputil"
 
-	"github.com/julienschmidt/httprouter"
+    "github.com/julienschmidt/httprouter"
 )
 
-func rootHandler(w http.ResponseWriter, r *http.Request, pr httprouter.Params)  {
-	dump, err := httputil.DumpRequest(r, true)
+func rootHandler(w http.ResponseWriter, r *http.Request, pr httprouter.Params) {
+    dump, err := httputil.DumpRequest(r, true)
 
-	if err != nil {
-		http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
-		return
-	}
+    if err != nil {
+        http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+        return
+    }
 
-	fmt.Println(string(dump))
+    fmt.Println(string(dump))
 
-	_, err = fmt.Fprint(w, "hello world!\n")
+    _, err = fmt.Fprint(w, "hello world!\n")
 
-	if err != nil {
-		http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
-		return
-	}
+    if err != nil {
+        http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+        return
+    }
 }
 
 func main()  {
-	// ルーティングの設定
-	router := httprouter.New()
-	router.GET("/", rootHandler)
+    // ルーティングの設定
+    router := httprouter.New()
+    router.GET("/", rootHandler)
 
-	// サーバ起動
-	fmt.Println("Server Start")
-	log.Fatal(http.ListenAndServe(":8080", router))
+    err := http.ListenAndServe(":8080", router)
+    if err != nil {
+        log.Fatalf("Listen and serve failed. %+v", err)
+    } else {
+        // サーバ起動
+        fmt.Println("Server Start")
+    }
 }

--- a/main.go
+++ b/main.go
@@ -19,8 +19,12 @@ func rootHandler(w http.ResponseWriter, r *http.Request, pr httprouter.Params)  
 
 	fmt.Println(string(dump))
 
-	// FIXME: Unhandled error
-	fmt.Fprint(w, "hello world!\n")
+	_, err = fmt.Fprint(w, "hello world!\n")
+
+	if err != nil {
+		http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+		return
+	}
 }
 
 func main()  {

--- a/main.go
+++ b/main.go
@@ -32,11 +32,7 @@ func main()  {
     router := httprouter.New()
     router.GET("/", rootHandler)
 
-    err := http.ListenAndServe(":8080", router)
-    if err != nil {
-        log.Fatalf("Listen and serve failed. %+v", err)
-    } else {
-        // サーバ起動
-        fmt.Println("Server Start")
-    }
+    // サーバ起動
+    fmt.Println("Server Start")
+    log.Fatal(http.ListenAndServe(":8080", router))
 }

--- a/main.go
+++ b/main.go
@@ -5,9 +5,11 @@ import (
 	"log"
 	"net/http"
 	"net/http/httputil"
+
+	"github.com/julienschmidt/httprouter"
 )
 
-func handler(w http.ResponseWriter, r *http.Request)  {
+func rootHandler(w http.ResponseWriter, r *http.Request, pr httprouter.Params)  {
 	dump, err := httputil.DumpRequest(r, true)
 
 	if err != nil {
@@ -22,13 +24,11 @@ func handler(w http.ResponseWriter, r *http.Request)  {
 }
 
 func main()  {
-	var httpServer http.Server
-	// Port number
-	httpServer.Addr = ":8080"
-	// Rooting
-	http.HandleFunc("/", handler)
-	// Log
-	log.Println("Server Start" + httpServer.Addr)
-	// Listen
-	log.Println(httpServer.ListenAndServe())
+	// ルーティングの設定
+	router := httprouter.New()
+	router.GET("/", rootHandler)
+
+	// サーバ起動
+	fmt.Println("Server Start")
+	log.Fatal(http.ListenAndServe(":8080", router))
 }


### PR DESCRIPTION
## 対象イシュー
Close #6 

## 概要
- `httprouter` パッケージ (https://github.com/julienschmidt/httprouter) を用いたルーティングに変える
- 上記に応じて，パッケージマネージャとして `Go Modules` を用いる
- 一部リファクタリングをした

## 技術的な内容
どこまで記述するべきかわからないけど，
- `go run` ではなく `go build` を使うと `Go Modules` のための `go.mod` や `go.sum` をいい感じに更新してくれる
- `EXPOSE 8080` は `Dockerfile` 上で明示的に宣言するためだと思っている
- (Slack において) 全然できないと言っていたエラーだけど，Docker を用いない場合に `Go Modules` を利用すると全然エラーを改善できない．Docker を使うと良好に動作するので，皆さん，環境依存しない Docker を使いましょう．
- `httprouter` を使う方が楽にルーティングできることは差分を見ればわかると思う

## 動作確認
Wiki を参照して欲しいが，前と変わらず
```
$ docker-compose up -d --build
```
をした後に，
```
curl localhost:8080
```
などを叩くと，`hello world!` と出力されることを確認してもらえばいい．動作は変わっていない．

## レビューの際に
正直，(自分も含めて) go 言語に精通してなさすぎるから（もしかしたら人によってはサーバサイド自体に）なんとも言えないけど，以下のような内容でググってくれたらわかることもあるかもしれない．
- Go Moudules
- Golang dockerfile
- go build
- golang dockerfile api