### PR TITLE
DB 接続の記述を共通化する

### DIFF
--- a/infrastructure/persistence/player.go
+++ b/infrastructure/persistence/player.go
@@ -20,6 +20,7 @@ func NewPlayerPersistence() repository.PlayerRepository {
         // DB との接続ができない場合には強制終了
         log.Fatal(err)
     }
+    log.Print("Succeed to connect database in `Player`")
 
     return &playerPersistence{db: db}
 }

--- a/infrastructure/persistence/player.go
+++ b/infrastructure/persistence/player.go
@@ -20,7 +20,7 @@ func NewPlayerPersistence() repository.PlayerRepository {
         // DB との接続ができない場合には強制終了
         log.Fatal(err)
     }
-    log.Print("Succeed to connect database in `Player`")
+    log.Print("Succeeded in connecting database in `Player`")
 
     return &playerPersistence{db: db}
 }

--- a/infrastructure/persistence/player.go
+++ b/infrastructure/persistence/player.go
@@ -1,6 +1,7 @@
 package persistence
 
 import (
+    "log"
     "time"
 
     "github.com/gobuffalo/pop"
@@ -9,21 +10,25 @@ import (
     "github.com/LITO-apps/Treevel-server/domain/repository"
 )
 
-type playerPersistence struct {}
+type playerPersistence struct {
+    db *pop.Connection
+}
 
 func NewPlayerPersistence() repository.PlayerRepository {
-    return &playerPersistence{}
+    db, err := pop.Connect("development")
+    if err != nil {
+        // DB との接続ができない場合には強制終了
+        log.Fatal(err)
+    }
+
+    return &playerPersistence{db: db}
 }
 
 func (pp playerPersistence) GetAllPlayers() ([]models.Player, error) {
     var players []models.Player
+    db := pp.db
 
-    db, err := pop.Connect("development")
-    if err != nil {
-        return nil, err
-    }
-
-    err = db.All(&players)
+    err := db.All(&players)
     if err != nil {
         return nil, err
     }
@@ -33,16 +38,12 @@ func (pp playerPersistence) GetAllPlayers() ([]models.Player, error) {
 
 func (pp playerPersistence) CreatePlayer(name string, t time.Time) error {
     player := models.Player{Name: name, LastLoginTime: t}
-    
-    db, err := pop.Connect("development")
+    db := pp.db
+
+    _, err := db.ValidateAndCreate(&player)
     if err != nil {
         return err
     }
 
-    _, err = db.ValidateAndCreate(&player)
-    if err != nil {
-        return err
-    }
-    
     return nil
 }

--- a/infrastructure/persistence/record.go
+++ b/infrastructure/persistence/record.go
@@ -19,6 +19,7 @@ func NewRecordPersistence() repository.RecordRepository {
         // DB との接続ができない場合には強制終了
         log.Fatal(err)
     }
+    log.Print("Succeed to connect database in `Record`")
 
     return &recordPersistence{db: db}
 }

--- a/infrastructure/persistence/record.go
+++ b/infrastructure/persistence/record.go
@@ -3,26 +3,31 @@ package persistence
 import (
     "github.com/gobuffalo/nulls"
     "github.com/gobuffalo/pop"
+    "log"
 
     "github.com/LITO-apps/Treevel-server/domain/models"
     "github.com/LITO-apps/Treevel-server/domain/repository"
 )
 
-type recordPersistence struct {}
+type recordPersistence struct {
+    db *pop.Connection
+}
 
 func NewRecordPersistence() repository.RecordRepository {
-    return &recordPersistence{}
+    db, err := pop.Connect("development")
+    if err != nil {
+        // DB との接続ができない場合には強制終了
+        log.Fatal(err)
+    }
+
+    return &recordPersistence{db: db}
 }
 
 func (rp recordPersistence) GetAllRecords() ([]models.Record, error) {
     var records []models.Record
+    db := rp.db
 
-    db, err := pop.Connect("development")
-    if err != nil {
-        return nil, err
-    }
-
-    err = db.All(&records)
+    err := db.All(&records)
     if err != nil {
         return nil, err
     }
@@ -32,7 +37,7 @@ func (rp recordPersistence) GetAllRecords() ([]models.Record, error) {
 
 func (rp recordPersistence) CreateRecord(playerID int, stageID int, isClear bool, playTimes int, firstClearTimes nulls.Int, minClearTime nulls.String) error {
     record := models.Record {
-        PlayerID: playerID, 
+        PlayerID: playerID,
         StageId: stageID,
         IsClear: isClear,
         PlayTimes: playTimes,
@@ -40,12 +45,9 @@ func (rp recordPersistence) CreateRecord(playerID int, stageID int, isClear bool
         MinClearTime: minClearTime,
     }
 
-    db, err := pop.Connect("development")
-    if err != nil {
-        return err
-    }
+    var db = rp.db
 
-    _, err = db.ValidateAndCreate(&record)
+    _, err := db.ValidateAndCreate(&record)
     if err != nil {
         return err
     }

--- a/infrastructure/persistence/record.go
+++ b/infrastructure/persistence/record.go
@@ -1,9 +1,10 @@
 package persistence
 
 import (
+    "log"
+
     "github.com/gobuffalo/nulls"
     "github.com/gobuffalo/pop"
-    "log"
 
     "github.com/LITO-apps/Treevel-server/domain/models"
     "github.com/LITO-apps/Treevel-server/domain/repository"
@@ -19,7 +20,7 @@ func NewRecordPersistence() repository.RecordRepository {
         // DB との接続ができない場合には強制終了
         log.Fatal(err)
     }
-    log.Print("Succeed to connect database in `Record`")
+    log.Print("Succeeded in connecting database in `Record`")
 
     return &recordPersistence{db: db}
 }


### PR DESCRIPTION
### 対象イシュー
Close #27 

### 概要
- タイトルまま
- 初期化処理を `**Persistence` が持つようにすることで共通化
- データベースの接続に成功した場合には，ログを出すようにした
- データベースの接続に失敗した場合には，プログラムが落ちるようにした

### 動作確認方法
- [x] 以前と同じようにデータベースの情報が取れること
- [x] データベースの接続に成功した場合に，ログが出ること

```
$ docker-compose up --build
```
※ `-d` をつけるとバックグラウンドで実行されてしまうので，付けないことでログを確認できる