### PR TITLE
ステージステータス更新API

### DIFF
--- a/domain/repository/record.go
+++ b/domain/repository/record.go
@@ -8,5 +8,6 @@ import (
 type RecordRepository interface {
     GetAllRecords() ([]models.Record, error)
     CreateRecord(int, string, bool, int, nulls.Int, nulls.Float32) error
+    UpdateRecord(int, string, bool, int, nulls.Int, nulls.Float32) error
     GetStageStat(string) (map[string]interface{}, error)
 }

--- a/handler/record.go
+++ b/handler/record.go
@@ -87,11 +87,11 @@ func (rh recordHandler) HandleGetStageStat(w http.ResponseWriter, r *http.Reques
 func (rh recordHandler) HandleUpdateStageStat(w http.ResponseWriter, r *http.Request) {
     vars := mux.Vars(r)
     stageID := vars["stage_id"]
+    playerID, err := strconv.Atoi(vars["player_id"])
 
-    // TODO: stageID validation
+    // TODO: stageID validation and playerID validation
 
     r.ParseForm();
-    playerID, err := strconv.Atoi(r.FormValue("player_id"))
     firstClearTimes, err := strconv.Atoi(r.FormValue("first_clear_times"))
     minClearTime, err := strconv.ParseFloat(r.FormValue("min_clear_time"), 32)
     isClear, err := strconv.ParseBool(r.FormValue("is_clear"))

--- a/handler/record.go
+++ b/handler/record.go
@@ -16,6 +16,7 @@ type RecordHandler interface {
     HandleGetAllRecords(http.ResponseWriter, *http.Request)
     HandleCreateRecord(http.ResponseWriter, *http.Request)
     HandleGetStageStat(http.ResponseWriter, *http.Request)
+    HandleUpdateStageStat(http.ResponseWriter, *http.Request)
 }
 
 type recordHandler struct {
@@ -77,6 +78,31 @@ func (rh recordHandler) HandleGetStageStat(w http.ResponseWriter, r *http.Reques
 
     err = enc.Encode(result)
 
+    if err != nil {
+        http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+        return
+    }
+}
+
+func (rh recordHandler) HandleUpdateStageStat(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    stageID := vars["stage_id"]
+
+    // TODO: stageID validation
+
+    r.ParseForm();
+    playerID, err := strconv.Atoi(r.FormValue("player_id"))
+    firstClearTimes, err := strconv.Atoi(r.FormValue("first_clear_times"))
+    minClearTime, err := strconv.ParseFloat(r.FormValue("min_clear_time"), 32)
+    isClear, err := strconv.ParseBool(r.FormValue("is_clear"))
+    playTimes, err := strconv.Atoi(r.FormValue("play_times"))
+
+    if err != nil {
+        http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
+        return
+    }
+
+    err = rh.recordUseCase.UpdateRecord(playerID, stageID, isClear, playTimes, nulls.Int{Int: firstClearTimes, Valid: err == nil}, nulls.NewFloat32(float32(minClearTime)))
     if err != nil {
         http.Error(w, fmt.Sprint(err), http.StatusInternalServerError)
         return

--- a/infrastructure/persistence/record.go
+++ b/infrastructure/persistence/record.go
@@ -57,6 +57,27 @@ func (rp recordPersistence) CreateRecord(playerID int, stageID string, isClear b
     return nil
 }
 
+func (rp recordPersistence) UpdateRecord(playerID int, stageID string, isClear bool, playTimes int, firstClearTimes nulls.Int, minClearTime nulls.Float32) error {
+    record := models.Record{}
+
+    db := rp.db
+
+    db.Where("stage_id = ?", stageID).Where("player_id = ?", playerID).First(&record)
+
+    record.IsClear = isClear
+    record.PlayTimes = playTimes
+    record.FirstClearTimes = firstClearTimes
+    record.MinClearTime = minClearTime
+
+    err := db.Update(&record)
+
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+
 func (rp recordPersistence) GetStageStat(stageID string) (map[string]interface{}, error) {
     minClearTime, err := rp.GetStageClearTime(stageID)
 

--- a/main.go
+++ b/main.go
@@ -30,6 +30,7 @@ func main() {
     router.HandleFunc("/create_player", playerHandler.HandleCreatePlayer).Methods("POST")
     router.HandleFunc("/create_record", recordHandler.HandleCreateRecord).Methods("POST")
     router.HandleFunc("/record/stats/stages/{stage_id:(?:Spring|Summer|Autumn|Winter)-[0-9]{1,2}-[0-9]{1,2}}", recordHandler.HandleGetStageStat).Methods("GET")
+    router.HandleFunc("/record/stats/stages/{stage_id:(?:Spring|Summer|Autumn|Winter)-[0-9]{1,2}-[0-9]{1,2}}", recordHandler.HandleUpdateStageStat).Methods("POST")
 
     // サーバ起動
     fmt.Println("Server Start")

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
     router.HandleFunc("/create_player", playerHandler.HandleCreatePlayer).Methods("POST")
     router.HandleFunc("/create_record", recordHandler.HandleCreateRecord).Methods("POST")
     router.HandleFunc("/record/stats/stages/{stage_id:(?:Spring|Summer|Autumn|Winter)-[0-9]{1,2}-[0-9]{1,2}}", recordHandler.HandleGetStageStat).Methods("GET")
-    router.HandleFunc("/record/stats/stages/{stage_id:(?:Spring|Summer|Autumn|Winter)-[0-9]{1,2}-[0-9]{1,2}}", recordHandler.HandleUpdateStageStat).Methods("POST")
+    router.HandleFunc("/record/stats/stages/{stage_id:(?:Spring|Summer|Autumn|Winter)-[0-9]{1,2}-[0-9]{1,2}}/{player_id}", recordHandler.HandleUpdateStageStat).Methods("POST")
 
     // サーバ起動
     fmt.Println("Server Start")

--- a/usecase/record.go
+++ b/usecase/record.go
@@ -9,6 +9,7 @@ import (
 type RecordUseCase interface {
     GetAllRecords() ([]models.Record, error)
     CreateRecord(int, string, bool, int, nulls.Int, nulls.Float32) error
+    UpdateRecord(int, string, bool, int, nulls.Int, nulls.Float32) error
     GetStageStat(string) (map[string]interface{}, error)
 }
 
@@ -41,6 +42,15 @@ func (ru recordUseCase) GetAllRecords() ([]models.Record, error) {
 
 func (ru recordUseCase) CreateRecord(playerID int, stageID string, isClear bool, playTimes int, firstClearTimes nulls.Int, minClearTime nulls.Float32) error {
     err := ru.recordRepository.CreateRecord(playerID, stageID, isClear, playTimes, firstClearTimes, minClearTime)
+    if err != nil {
+        return err
+    }
+
+    return nil
+}
+
+func (ru recordUseCase) UpdateRecord(playerID int, stageID string, isClear bool, playTimes int, firstClearTimes nulls.Int, minClearTime nulls.Float32) error {
+    err := ru.recordRepository.UpdateRecord(playerID, stageID, isClear, playTimes, firstClearTimes, minClearTime)
     if err != nil {
         return err
     }


### PR DESCRIPTION
### 対象イシュー
Close #32

### 概要
ステージステータス更新APIを実装

### 詳細

#### 現実装になった経緯

基本的に `CreateRecord` をコピーして最後の `persistence`層でDBとのやりとりだけ `Update` にした実装になります。
 
#### 技術的な内容


### キャプチャ


### 動作確認方法 
- [ ] 下記コマンドでリクエストを送り、データベースからデータが変わったことを確認してください。

```
$ curl -X POST -d "player_id=1&is_clear=1&play_times=2&first_clear_times=1&min_clear_time=1111" localhost:8080/record/stats/stages/Spring-1-1
```


### 参考 URL
